### PR TITLE
Update dev.ini

### DIFF
--- a/requirements/dev.ini
+++ b/requirements/dev.ini
@@ -3,7 +3,7 @@
 
 ansible==2.7.5
 django-debug-toolbar==1.11
-fabric3==1.14.post1
+fabric==2.4.0
 flake8==3.6.0
 ipdb==0.11
 isort==4.3.4

--- a/requirements/dev.ini
+++ b/requirements/dev.ini
@@ -3,6 +3,7 @@
 
 ansible==2.7.5
 django-debug-toolbar==1.11
+fabric3==1.14.post1
 flake8==3.6.0
 ipdb==0.11
 isort==4.3.4


### PR DESCRIPTION
We should add fabric3 in dev.ini, otherwise any 'make dev' will delete it, not being in requirements ini files.